### PR TITLE
Choose BCM943602CS over BCM94360NG and enhance README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@
 | SD Card Reader | Realtek USB Card Reader RTS5129 *(Limited support)* |
 | UEFI BIOS | Aptio Setup Utility P05AEK |
 
+##  Before you begin
+### Hardware and UEFI mods required
+1. eGPU is required for graphics acceleration.
+2. UEFI mod is required to route output from iGPU to eGPU at UEFI setup and OpenCore bootpicker.
+
 ## UEFI setup
 ### Using modded Aptio Setup Utility image
 1. Learn how to flash AMI UEFI. This may brick the computer, so I don’t recommend it unless you understand the consequences and know how to unbrick in case something goes wrong.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If you have a variant such as DM500A2J-K30D, K32D, or K38D, you will notice that
   2. Inject a working `ig-platform-id` and `SSDT-PNLF` found in OpenCorePkg bundle for working iGPU QE/CI and native brightness control. Test the HDMI-out and configure the framebuffer.
   3. Change `SMBIOS` to iMac14,4 which is an iGPU-only model. You can update to Big Sur with no problem. You still have DRM and sound noise issues.
   4. Insert BCM94360 variants into mini PCIe. There are three antennas on the mainboard: two from Atheros AR9565 / AR3012 and one from TV Tuner Card originally on mini PcIe slot. All share the form factor of U.FL. Although there are many other options, I would recommend BCM943602CS with adapters and U.FL to MHF4 cables, so that both Wi-Fi and Bluetooth are natively supported with full Apple Airport features and full speed. The adapters are shown in [Bluetooth enhancement](#bluetooth-enhancement).
-  5. Study and create an AppleALC layout and fix sound noise.
+  5. Create an AppleALC layout and fix sound noise.
 
 ## Bluetooth enhancement
 Atheros AR3012 Bluetooth works okay with Ath3kBT.kext. However, I had a leftover Apple's BCM94360CS2 which can be converted into a USB2 device, where Bluetooth over USB can be used. I bought USB to mini PCIe to M.2 A+E key to Apple Airport card converters, and the Bluetooth works the same way as in a real Mac, such as OS recognition and HID proxy.

--- a/README.md
+++ b/README.md
@@ -50,15 +50,13 @@ If you have a variant such as DM500A2J-K30D, K32D, or K38D, you will notice that
   1. Delete the kernel patch `Fake CPUID` and enjoy native power management and advanced CPU features.
   2. Inject a working `ig-platform-id` and `SSDT-PNLF` found in OpenCorePkg bundle for working iGPU QE/CI and native brightness control. Test the HDMI-out and configure the framebuffer.
   3. Change `SMBIOS` to iMac14,4 which is an iGPU-only model. You can update to Big Sur with no problem. You still have DRM and sound noise issues.
-  4. Insert BCM94360 variants into mini PCIe. There are three antennas on the mainboard: two from Atheros AR9565 / AR3012 and one from TV Tuner Card originally on mini PcIe slot. All share the form factor of U.FL. Although there are many other options, I would recommend BCM94360NG with mini PCIe to M.2 A+E key adapter, so that both Wi-Fi and Bluetooth are natively supported with full Apple Airport features.
+  4. Insert BCM94360 variants into mini PCIe. There are three antennas on the mainboard: two from Atheros AR9565 / AR3012 and one from TV Tuner Card originally on mini PcIe slot. All share the form factor of U.FL. Although there are many other options, I would recommend BCM943602CS with adapters and antennas, so that both Wi-Fi and Bluetooth are natively supported with full Apple Airport features and full speed.
   5. Study and create an AppleALC layout and fix sound noise.
 
 ## Bluetooth enhancement
 Atheros AR3012 Bluetooth works okay with Ath3kBT.kext. However, I had a leftover Apple's BCM94360CS2 which can be converted into a USB2 device, where Bluetooth over USB can be used. I bought USB to mini PCIe to M.2 A+E key to Apple Airport card converters, and the Bluetooth works the same way as in a real Mac, such as OS recognition and HID proxy.
 
 ![](images/UsbBluetooth.jpg)
-
-Another option with BCM94360NG is mentioned in [Other models](#other-models) plus USB to mini PCIe.
 
 ## Credits
 Apple for macOS

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@
 
 ## Updating VBIOS with GOP driver
 1. Follow the directions found in [this](https://www.win-raid.com/t892f16-AMD-and-Nvidia-GOP-update-No-requests-DIY.html) thread.
-- Note: The ROM images in this repository are specifically for Sapphire HD 7750 1GB with device-id 1002:683F and subsystem-id 174B:E213. Follow the update method for your own card.
+- Note 1: This step is only required for dGPUs with legacy ROMs. If you have a model that is manufactured relatively recently, you would not need to follow this step. Check online.
+- Note 2: The ROM images in this repository are specifically for Sapphire HD 7750 1GB with device-id 1002:683F and subsystem-id 174B:E213. Follow the update method for your own card.
 
 ## Steps to install
 1. Read [Configuration.pdf](https://github.com/acidanthera/OpenCorePkg/blob/master/Docs/Configuration.pdf).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you have a variant such as DM500A2J-K30D, K32D, or K38D, you will notice that
   1. Delete the kernel patch `Fake CPUID` and enjoy native power management and advanced CPU features.
   2. Inject a working `ig-platform-id` and `SSDT-PNLF` found in OpenCorePkg bundle for working iGPU QE/CI and native brightness control. Test the HDMI-out and configure the framebuffer.
   3. Change `SMBIOS` to iMac14,4 which is an iGPU-only model. You can update to Big Sur with no problem. You still have DRM and sound noise issues.
-  4. Insert BCM94360 variants into mini PCIe. There are three antennas on the mainboard: two from Atheros AR9565 / AR3012 and one from TV Tuner Card originally on mini PcIe slot. All share the form factor of U.FL. Although there are many other options, I would recommend BCM943602CS with adapters and antennas, so that both Wi-Fi and Bluetooth are natively supported with full Apple Airport features and full speed.
+  4. Insert BCM94360 variants into mini PCIe. There are three antennas on the mainboard: two from Atheros AR9565 / AR3012 and one from TV Tuner Card originally on mini PcIe slot. All share the form factor of U.FL. Although there are many other options, I would recommend BCM943602CS with adapters and antennas, so that both Wi-Fi and Bluetooth are natively supported with full Apple Airport features and full speed. The adapters are shown in [Bluetooth enhancement](#bluetooth-enhancement).
   5. Study and create an AppleALC layout and fix sound noise.
 
 ## Bluetooth enhancement

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you have a variant such as DM500A2J-K30D, K32D, or K38D, you will notice that
   1. Delete the kernel patch `Fake CPUID` and enjoy native power management and advanced CPU features.
   2. Inject a working `ig-platform-id` and `SSDT-PNLF` found in OpenCorePkg bundle for working iGPU QE/CI and native brightness control. Test the HDMI-out and configure the framebuffer.
   3. Change `SMBIOS` to iMac14,4 which is an iGPU-only model. You can update to Big Sur with no problem. You still have DRM and sound noise issues.
-  4. Insert BCM94360 variants into mini PCIe. There are three antennas on the mainboard: two from Atheros AR9565 / AR3012 and one from TV Tuner Card originally on mini PcIe slot. All share the form factor of U.FL. Although there are many other options, I would recommend BCM943602CS with adapters and antennas, so that both Wi-Fi and Bluetooth are natively supported with full Apple Airport features and full speed. The adapters are shown in [Bluetooth enhancement](#bluetooth-enhancement).
+  4. Insert BCM94360 variants into mini PCIe. There are three antennas on the mainboard: two from Atheros AR9565 / AR3012 and one from TV Tuner Card originally on mini PcIe slot. All share the form factor of U.FL. Although there are many other options, I would recommend BCM943602CS with adapters and U.FL to MHF4 cables, so that both Wi-Fi and Bluetooth are natively supported with full Apple Airport features and full speed. The adapters are shown in [Bluetooth enhancement](#bluetooth-enhancement).
   5. Study and create an AppleALC layout and fix sound noise.
 
 ## Bluetooth enhancement


### PR DESCRIPTION
BCM94360NG suffers from limited Wi-Fi speed capped at 400 Mbps.